### PR TITLE
Only include files in `dist` in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "name": "Mohsen Madani",
     "email": "mohsenando@gmail.com"
   },
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
There are a lot of unrelated files in the npm package: https://www.unpkg.com/browse/js-abbreviation-number@1.1.0/

This change would remove all the files except the 2 required ones and the defaults (readme, license, package.json)