### PR TITLE
Always build before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "jest --config=jest.config.json --collectCoverage",
     "build": "tsc",
+    "prepare": "tsc",
     "lint": "./node_modules/.bin/eslint *.ts",
     "prettier-write": "./node_modules/.bin/prettier --write \"*.ts\"",
     "prettier-check": "./node_modules/.bin/prettier --check \"*.ts\"",


### PR DESCRIPTION
https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts

This avoids https://github.com/moh3n9595/js-abbreviation-number/pull/6#issuecomment-800616763