### PR TITLE
Fix sign of the small negative numbers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,7 @@ export function abbreviateNumber(
   const tier = (Math.log10(num) / 3) | 0;
 
   // if zero, we don't need a suffix
-  if (tier == 0) return num.toString();
+  if (tier == 0) return (!sign ? "-" : "") + num.toString();
 
   // get suffix and determine scale
   const suffix = symbols[tier];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,13 @@
 import { abbreviateNumber } from "../index";
 
+test("-25 should be --> -25", () => {
+  expect(abbreviateNumber(-25, 0)).toBe("-25");
+});
+
+test("-999 should be --> -999", () => {
+  expect(abbreviateNumber(-999, 2)).toBe("-999");
+});
+
 test("1000 should be --> 1K", () => {
   expect(abbreviateNumber(1000, 0)).toBe("1K");
 });


### PR DESCRIPTION
When I have a small negative number without a suffix, for example -500, the function doesn't return the sign.
For example: -500 was returning 500.